### PR TITLE
Add validation for token address

### DIFF
--- a/app/css/index.css
+++ b/app/css/index.css
@@ -995,6 +995,10 @@ video {
 	border-style: dashed;
 }
 
+.border-orange-400\/50 {
+	border-color: rgb(251 146 60 / 0.5);
+}
+
 .border-red-400 {
 	--tw-border-opacity: 1;
 	border-color: rgb(248 113 113 / var(--tw-border-opacity));
@@ -1069,6 +1073,10 @@ video {
 .bg-neutral-900 {
 	--tw-bg-opacity: 1;
 	background-color: rgb(23 23 23 / var(--tw-bg-opacity));
+}
+
+.bg-orange-400\/10 {
+	background-color: rgb(251 146 60 / 0.1);
 }
 
 .bg-red-200\/10 {
@@ -1287,6 +1295,10 @@ video {
 
 .text-white\/50 {
 	color: rgb(255 255 255 / 0.5);
+}
+
+.text-white\/75 {
+	color: rgb(255 255 255 / 0.75);
 }
 
 .text-white\/80 {

--- a/app/ts/components/TransferPage/Validation.tsx
+++ b/app/ts/components/TransferPage/Validation.tsx
@@ -1,0 +1,49 @@
+import { Signal, useComputed } from '@preact/signals'
+import { useAccount } from '../../store/account.js'
+import { useAccountTokens } from '../../store/tokens.js'
+import { TransferData } from '../../store/transfer.js'
+import * as Icon from '../Icon/index.js'
+
+type Props = {
+	data: Signal<TransferData>
+}
+
+export const TransferValidation = (props: Props) => {
+	const { address } = useAccount()
+	const { tokens } = useAccountTokens()
+
+	const isRecipientAToken = useComputed(() => tokens.value.some(token => token.address.toLowerCase() === props.data.value.recipientAddress.toLowerCase()))
+
+	const isRecipientOwn = useComputed(() => {
+		if (address.value.state !== 'resolved') return false
+		return address.value.value.toLowerCase() === props.data.value.recipientAddress.toLowerCase()
+	})
+
+	if (isRecipientAToken.value)
+		return (
+			<div class='grid grid-cols-[auto,1fr] items-center border border-orange-400/50 bg-orange-400/10 px-4 gap-4'>
+				<Icon.Info class='text-4xl' />
+				<div class='py-3'>
+					<div>
+						<strong>Warning:</strong> Recipient is a Token address
+					</div>
+					<div class='leading-tight text-white/75 text-sm'>The recipient address provided is a known token address and may be unintentional. Tokens sent to this address may be unrecoverable.</div>
+				</div>
+			</div>
+		)
+
+	if (isRecipientOwn.value) {
+		return (
+			<div class='grid grid-cols-[auto,1fr] items-center border border-orange-400/50 bg-orange-400/10 px-4 gap-4'>
+				<Icon.Info class='text-4xl' />
+				<div class='py-3'>
+					<div>
+						<strong>Warning:</strong> Recipient is the same as source
+					</div>
+					<div class='leading-tight text-white/75 text-sm'>The recipient address provided the same as the source address and may be unintentional. Proceeding will incur transaction fees.</div>
+				</div>
+			</div>
+		)
+	}
+	return <></>
+}

--- a/app/ts/components/TransferPage/index.tsx
+++ b/app/ts/components/TransferPage/index.tsx
@@ -13,6 +13,7 @@ import { TransactionResponse } from '../../types.js'
 import { RecentTransfers } from '../RecentTransfers.js'
 import { DiscordInvite } from '../DiscordInvite.js'
 import { AddTokenDialog } from './AddTokenDialog.js'
+import { TransferValidation } from './Validation.js'
 
 const SCROLL_OPTIONS = { inline: 'start', behavior: 'smooth' } as const
 
@@ -83,6 +84,7 @@ const MainPanel = () => {
 						</div>
 						<AddressField label='Address' placeholder='0x123...789' value={data.value.recipientAddress} onInput={handleAddressChange} onClear={handleAddressChange} disabled={isFormSubmitting.value} />
 						<TransferStatus transaction={transaction} />
+						<TransferValidation data={data} />
 						<SubmitButton disabled={isFormSubmitting.value} />
 					</div>
 				</form>

--- a/app/ts/store/transfer.ts
+++ b/app/ts/store/transfer.ts
@@ -7,7 +7,7 @@ import { useProviders } from './provider.js'
 import { useRecentTransfers } from './recent-transfers.js'
 import { TokenMeta } from './tokens.js'
 
-type TransferData = {
+export type TransferData = {
 	recipientAddress: string
 	amount: string
 	token?: TokenMeta


### PR DESCRIPTION
Resolves #108

- [x] warn user for sending to a known token address
- [x] warn user for sending to own address

| <img width="437" alt="Screenshot 2023-06-04 at 9 58 12 AM" src="https://github.com/DarkFlorist/lunaria/assets/1169838/7d39cf99-2cfa-4ab8-8492-890b78b349ec"> | 
|:--:| 
| *If recipient address is the same as source* |

| <img width="437" alt="Screenshot 2023-06-04 at 9 57 57 AM" src="https://github.com/DarkFlorist/lunaria/assets/1169838/6bc19f63-9aab-45b2-ba88-b16182eb76ae"> | 
|:--:| 
| *If recipient address is a token* |





