### PR TITLE
Add Lunaria favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://lunaria.dark.florist/
 For a more complete workflow on managing your assets, checkout these projects!
 
 - [TheInterceptor](https://github.com/DarkFlorist/TheInterceptor)
-- [Boquet](https://github.com/DarkFlorist/bouquet)
+- [Bouquet](https://github.com/DarkFlorist/bouquet)
 
 ## Commands
 

--- a/app/index.html
+++ b/app/index.html
@@ -5,6 +5,7 @@
 	<title>Lunaria</title>
 	<meta charset='utf-8' />
 	<meta name='viewport' content='width=device-width, initial-scale=1.0' />
+	<link rel="icon" type="image/svg+xml" href="./img/icon-lunaria.svg" />
 	<link rel='stylesheet' href='./css/index.css' />
 	<style>
 		.splash-screen {


### PR DESCRIPTION
Resolves #130
Resolves #105 

- [x] use main site svg as favicon
- [x] ~~support other methods of displaying favicons~~

Utilizing the svg on the main page should work, just need to review for other machines first.

| <img width="348" alt="Screenshot 2023-06-04 at 10 31 01 AM" src="https://github.com/DarkFlorist/lunaria/assets/1169838/70aecff3-ee9b-4988-93b3-3896285b860a"> |
|:--:|
| *Using brave browser* |

Update:
- I just sneaked in the readme fix here as it's very small