### PR TITLE
Make save transfer label optional

### DIFF
--- a/app/ts/components/Favorites.tsx
+++ b/app/ts/components/Favorites.tsx
@@ -37,11 +37,11 @@ export const Favorites = () => {
 								<div class='text-left'>
 									<div>{favorite.label}</div>
 									<div class='overflow-hidden text-ellipsis whitespace-nowrap text-sm text-white/50'>
-									{favorite.amount} {favorite.token ? favorite.token.symbol : 'ETH'} to {favorite.recipientAddress}
+										{favorite.amount} {favorite.token ? favorite.token.symbol : 'ETH'} to {favorite.recipientAddress}
 									</div>
 								</div>
 							</div>
-							<RemoveButton show={manage.value === true} favorite={favorite} />
+							<RemoveButton show={manage.value === true} index={index} />
 						</a>
 					)
 				})}
@@ -69,18 +69,18 @@ const MoveUpButton = (props: PromoteButtonProps) => {
 	)
 }
 
-type RemoveButton = {
+type RemoveButtonProps = {
 	show: boolean
-	favorite: FavoriteModel
+	index: number
 }
 
-const RemoveButton = (props: RemoveButton) => {
+const RemoveButton = (props: RemoveButtonProps) => {
 	const { remove } = useFavorites()
 
 	if (!props.show) return <></>
 
 	return (
-		<button class='text-sm' onClick={() => remove(props.favorite.label)}>
+		<button class='text-sm' onClick={() => remove(props.index)}>
 			<Icon.Xmark />
 		</button>
 	)

--- a/app/ts/components/SVGBlockie.tsx
+++ b/app/ts/components/SVGBlockie.tsx
@@ -1,5 +1,7 @@
 // ported directly from https://github.com/DarkFlorist/TheInterceptor
 
+import { useMemo } from "preact/hooks";
+
 function generateIdenticon(options: { seed: string; size?: number }) {
 	// NOTE -- Majority of this code is referenced from: https://github.com/alexvandesande/blockies
 	// Mostly to ensure congruence to Ethereum Mist's Identicons

--- a/app/ts/components/TransactionPage/SaveTransfer.tsx
+++ b/app/ts/components/TransactionPage/SaveTransfer.tsx
@@ -53,7 +53,7 @@ const AddFavoriteForm = ({ addFavoriteStore, onSubmit }: SaveFormProps) => {
 					</div>
 					<form class='w-full' onSubmit={submitForm}>
 						<div class='grid gap-2 items-center w-full'>
-							<input class='border border-white/30 px-4 py-2 bg-transparent outline-none min-w-auto' type='text' value={addFavoriteStore.value.label} onInput={event => (addFavoriteStore.value = { ...addFavoriteStore.peek(), label: event.currentTarget.value })} placeholder='Add a label' required />
+							<input class='border border-white/30 px-4 py-2 bg-transparent outline-none min-w-auto' type='text' value={addFavoriteStore.value.label} onInput={event => (addFavoriteStore.value = { ...addFavoriteStore.peek(), label: event.currentTarget.value })} placeholder='Add a label (optional)' />
 							<button type='submit' class='border border-white/50 bg-white/10 px-4 py-3 outline-none focus:bg-white/20 hover:bg-white/20'>
 								Save
 							</button>

--- a/app/ts/components/TransferPage/Validation.tsx
+++ b/app/ts/components/TransferPage/Validation.tsx
@@ -31,7 +31,7 @@ export const TransferValidation = (props: Props) => {
 
 					<label class='flex gap-2 items-center'>
 						<input type='checkbox' required />
-						<span>I understand that this will probably result in the loss of {props.data.value.amount} {props.data.value.symbol}.</span>
+						<span>I understand that this will probably result in the loss of {props.data.value.amount} {props.data.value.token?.symbol}.</span>
 					</label>
 				</div>
 			</div>

--- a/app/ts/store/favorites.ts
+++ b/app/ts/store/favorites.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'preact/hooks'
 import { TokenMeta } from './tokens'
 
 export type FavoriteModel = {
-	label: string
+	label?: string
 	source: string
 	recipientAddress: string
 	token?: TokenMeta

--- a/app/ts/store/favorites.ts
+++ b/app/ts/store/favorites.ts
@@ -49,8 +49,8 @@ export function useFavorites() {
 		favorites.value = [...current, data]
 	}
 
-	const remove = (label: string) => {
-		favorites.value = favorites.value.filter(favorite => favorite.label !== label)
+	const remove = (index: number) => {
+		favorites.value = [...favorites.peek().slice(0, index), ...favorites.peek().slice(index + 1)]
 	}
 
 	const swapIndex = (indexA: number, indexB: number) => {


### PR DESCRIPTION
Remove requirement for transfer label when saving a transaction
Resolves #145 