### PR TITLE
Remove @node/types and add workaround

### DIFF
--- a/build/package-lock.json
+++ b/build/package-lock.json
@@ -1,20 +1,13 @@
 {
 	"name": "build",
-	"lockfileVersion": 2,
+	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"devDependencies": {
-				"@types/node": "16.11.7",
 				"@zoltu/file-copier": "2.2.1",
 				"typescript": "4.7.3"
 			}
-		},
-		"node_modules/@types/node": {
-			"version": "16.11.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-			"integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==",
-			"dev": true
 		},
 		"node_modules/@zoltu/file-copier": {
 			"version": "2.2.1",
@@ -34,26 +27,6 @@
 			"engines": {
 				"node": ">=4.2.0"
 			}
-		}
-	},
-	"dependencies": {
-		"@types/node": {
-			"version": "16.11.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-			"integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==",
-			"dev": true
-		},
-		"@zoltu/file-copier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@zoltu/file-copier/-/file-copier-2.2.1.tgz",
-			"integrity": "sha512-EsCYPddSwciz80ApK0H/rv+fUZVFly5VkZ1AhjxSDXcte81WkBZp6mP8Ai/2JFWfyPmfJVKEoIVYD5EIPhz4og==",
-			"dev": true
-		},
-		"typescript": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-			"dev": true
 		}
 	}
 }

--- a/build/package.json
+++ b/build/package.json
@@ -1,7 +1,6 @@
 {
 	"type": "module",
 	"devDependencies": {
-		"@types/node": "16.11.7",
 		"@zoltu/file-copier": "2.2.1",
 		"typescript": "4.7.3"
 	},

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -10,12 +10,12 @@
 		"noUnusedParameters": true,
 		"noImplicitReturns": true,
 		"noImplicitThis": true,
-		"lib": [ "ES2020" ],
+		"lib": ["ES2020"],
+		"typeRoots": ["./node_modules/@types"],
+		"types": []
 	},
-	"include": [
-		"./*.ts"
-	],
+	"include": ["./*.ts"],
 	"ts-node": {
-		"esm": true,
+		"esm": true
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
 		},
 		"node_modules/@preact/signals-core": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.2.1.tgz",
 			"integrity": "sha512-aqzRMNFU1hoQyP4Kb1ldJrUTCnA9vqPDa7qHEQzHJ3upnBOcC2pjmvjAuTqGuY4AVTtUkCQV0FvOCuIQQ2hSdA==",
 			"funding": {
 				"type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "lunaria",
-	"lockfileVersion": 2,
+	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
@@ -58,9 +58,9 @@
 			}
 		},
 		"node_modules/@preact/signals-core": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.2.1.tgz",
-			"integrity": "sha512-aqzRMNFU1hoQyP4Kb1ldJrUTCnA9vqPDa7qHEQzHJ3upnBOcC2pjmvjAuTqGuY4AVTtUkCQV0FvOCuIQQ2hSdA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.3.1.tgz",
+			"integrity": "sha512-DL+3kDssZ3UOMz9HufwSYE/gK0+TnT1jzegfF5rstgyPrnyfjz4BHAoxmzQA6Mkp4UlKe8qjsgl3v5a/obzNig==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
@@ -149,82 +149,6 @@
 					"optional": true
 				}
 			}
-		}
-	},
-	"dependencies": {
-		"@adraffy/ens-normalize": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
-			"integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
-		},
-		"@noble/hashes": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-			"integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
-		},
-		"@noble/secp256k1": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-			"integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
-		},
-		"@preact/signals": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.1.1.tgz",
-			"integrity": "sha512-I1DhYo2d1t9qDkEq1jYDVTQdBGmo4NlqatNEtulsS/87kVdwhZluP6TTDS4/5sc2h86TlBF6UA6LO+tDpIt/Gw==",
-			"requires": {
-				"@preact/signals-core": "^1.2.0"
-			}
-		},
-		"@preact/signals-core": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.2.1.tgz",
-			"integrity": "sha512-aqzRMNFU1hoQyP4Kb1ldJrUTCnA9vqPDa7qHEQzHJ3upnBOcC2pjmvjAuTqGuY4AVTtUkCQV0FvOCuIQQ2hSdA=="
-		},
-		"@types/node": {
-			"version": "18.15.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-			"integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
-		},
-		"aes-js": {
-			"version": "4.0.0-beta.5",
-			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-			"integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
-		},
-		"ethers": {
-			"version": "6.6.4",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.6.4.tgz",
-			"integrity": "sha512-r3myN2hEnydmu23iiIj5kjWnCh5JNzlqrE/z+Kw5UqH173F+JOWzU6qkFB4HVC50epgxzKSL2Hq1oNXA877vwQ==",
-			"requires": {
-				"@adraffy/ens-normalize": "1.9.2",
-				"@noble/hashes": "1.1.2",
-				"@noble/secp256k1": "1.7.1",
-				"@types/node": "18.15.13",
-				"aes-js": "4.0.0-beta.5",
-				"tslib": "2.4.0",
-				"ws": "8.5.0"
-			}
-		},
-		"preact": {
-			"version": "10.8.1",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.8.1.tgz",
-			"integrity": "sha512-p5CKQ0MCEXTGKGOHiFaNE2V2nDq2hvDHykXvIlz+4lbfJ9umLZr8JS/fa1bXUwRcHXK+Ljk8zqmDhr25n0LtVg=="
-		},
-		"tslib": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-		},
-		"typescript": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-			"integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
-			"dev": true
-		},
-		"ws": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-			"requires": {}
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,9 +58,9 @@
 			}
 		},
 		"node_modules/@preact/signals-core": {
-			"version": "1.3.1",
+			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.3.1.tgz",
-			"integrity": "sha512-DL+3kDssZ3UOMz9HufwSYE/gK0+TnT1jzegfF5rstgyPrnyfjz4BHAoxmzQA6Mkp4UlKe8qjsgl3v5a/obzNig==",
+			"integrity": "sha512-aqzRMNFU1hoQyP4Kb1ldJrUTCnA9vqPDa7qHEQzHJ3upnBOcC2pjmvjAuTqGuY4AVTtUkCQV0FvOCuIQQ2hSdA==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,17 +16,9 @@
 		"noImplicitThis": true,
 		"jsx": "react-jsx",
 		"jsxImportSource": "preact",
-		"lib": [
-			"ES2021",
-			"DOM"
-		],
-		"typeRoots": [
-			"./node_modules/@types",
-			"./typings",
-		]
+		"lib": ["ES2021", "DOM"],
+		"typeRoots": ["./node_modules/@types"],
+		"types": []
 	},
-	"include": [
-		"./app/ts/**/*.ts",
-		"./app/ts/**/*.tsx",
-	],
+	"include": ["./app/ts/**/*.ts", "./app/ts/**/*.tsx"]
 }

--- a/typings/node/index.d.ts
+++ b/typings/node/index.d.ts
@@ -1,7 +1,0 @@
-export {}
-
-declare global {
-	namespace NodeJS {
-		type Timer = number
-	}
-}


### PR DESCRIPTION
A workaround from this template was applied to prevent issues from ethers.js' @node/types dependency when used on a browser environment
https://github.com/Zoltu/preact-es2015-template/blob/master/tsconfig.json#L28-L30