### PR TITLE
Fix provider fail silently when using signal

### DIFF
--- a/app/ts/components/ConnectAccount.tsx
+++ b/app/ts/components/ConnectAccount.tsx
@@ -1,34 +1,36 @@
 import { useAccount } from '../store/account.js'
+import { ApplicationError } from '../store/errors.js'
 import { useNetwork } from '../store/network.js'
-import { useNotice } from '../store/notice.js'
-import { useProviders } from '../store/provider.js'
 import { AsyncText } from './AsyncText.js'
 import SVGBlockie from './SVGBlockie.js'
 
 export const ConnectAccount = () => {
 	const { address, connect } = useAccount()
-	const providers = useProviders()
-	const { notify } = useNotice()
-
-	const connectAccount = () => {
-		try {
-			providers.browserProvider.value // catch the error in initializing provider
-			connect()
-		} catch {
-			notify({ title: 'Error', message: 'No compatible web3 wallet detected' })
-		}
-	}
 
 	switch (address.value.state) {
 		case 'inactive':
-		case 'rejected':
 			return (
 				<div class='grid grid-cols-[1fr,auto] gap-3 px-4 lg:px-0 h-20 border border-white/20 lg:border-none lg:place-items-end place-content-center items-center'>
 					<div class='grid lg:place-items-end'>
 						<span class='font-bold'>Get started quickly</span>
 						<span class='text-sm text-white/50'>by connecting your wallet</span>
 					</div>
-					<button class='h-12 px-4 border border-white/50 bg-white/20' onClick={connectAccount}>
+					<button class='h-12 px-4 border border-white/50 bg-white/20' onClick={connect}>
+						Connect
+					</button>
+				</div>
+			)
+		case 'rejected':
+			if (address.value.error instanceof ApplicationError) {
+				console.log('attempt fail')
+			}
+			return (
+				<div class='grid grid-cols-[1fr,auto] gap-3 px-4 lg:px-0 h-20 border border-white/20 lg:border-none lg:place-items-end place-content-center items-center'>
+					<div class='grid lg:place-items-end'>
+						<span class='font-bold'>Get started quickly</span>
+						<span class='text-sm text-white/50'>by connecting your wallet</span>
+					</div>
+					<button class='h-12 px-4 border border-white/50 bg-white/20' onClick={connect}>
 						Connect
 					</button>
 				</div>
@@ -106,7 +108,6 @@ const WalletNetwork = () => {
 
 const NetworkName = () => {
 	const { network } = useNetwork()
-	console.log(network.value)
 
 	switch (network.value.state) {
 		case 'inactive':

--- a/app/ts/components/ConnectAccount.tsx
+++ b/app/ts/components/ConnectAccount.tsx
@@ -1,5 +1,4 @@
 import { useAccount } from '../store/account.js'
-import { ApplicationError } from '../store/errors.js'
 import { useNetwork } from '../store/network.js'
 import { AsyncText } from './AsyncText.js'
 import SVGBlockie from './SVGBlockie.js'
@@ -9,21 +8,7 @@ export const ConnectAccount = () => {
 
 	switch (address.value.state) {
 		case 'inactive':
-			return (
-				<div class='grid grid-cols-[1fr,auto] gap-3 px-4 lg:px-0 h-20 border border-white/20 lg:border-none lg:place-items-end place-content-center items-center'>
-					<div class='grid lg:place-items-end'>
-						<span class='font-bold'>Get started quickly</span>
-						<span class='text-sm text-white/50'>by connecting your wallet</span>
-					</div>
-					<button class='h-12 px-4 border border-white/50 bg-white/20' onClick={connect}>
-						Connect
-					</button>
-				</div>
-			)
 		case 'rejected':
-			if (address.value.error instanceof ApplicationError) {
-				console.log('attempt fail')
-			}
 			return (
 				<div class='grid grid-cols-[1fr,auto] gap-3 px-4 lg:px-0 h-20 border border-white/20 lg:border-none lg:place-items-end place-content-center items-center'>
 					<div class='grid lg:place-items-end'>

--- a/app/ts/components/TokenManager/EtherBalance.tsx
+++ b/app/ts/components/TokenManager/EtherBalance.tsx
@@ -17,8 +17,7 @@ export const EtherBalance = () => {
 		if (address.value.state !== 'resolved') return
 		const accountAddress = address.value.value
 		waitFor(async () => {
-			const provider = providers.browserProvider
-			return await provider.getBalance(accountAddress)
+			return await providers.browserProvider.getBalance(accountAddress)
 		})
 	}
 

--- a/app/ts/components/TokenManager/EtherBalance.tsx
+++ b/app/ts/components/TokenManager/EtherBalance.tsx
@@ -17,7 +17,7 @@ export const EtherBalance = () => {
 		if (address.value.state !== 'resolved') return
 		const accountAddress = address.value.value
 		waitFor(async () => {
-			const provider = providers.browserProvider.value
+			const provider = providers.browserProvider
 			return await provider.getBalance(accountAddress)
 		})
 	}

--- a/app/ts/components/TransactionPage/TransactionDetails.tsx
+++ b/app/ts/components/TransactionPage/TransactionDetails.tsx
@@ -191,7 +191,7 @@ const AccountBalance = ({ receipt, onResolve }: { receipt: TransactionReceiptPar
 	const getBalance = () => {
 		const { from, blockNumber } = receipt
 		waitFor(async () => {
-			const provider = providers.browserProvider.value
+			const provider = providers.browserProvider
 			return await provider.getBalance(from, blockNumber)
 		})
 	}

--- a/app/ts/components/TransactionPage/TransactionDetails.tsx
+++ b/app/ts/components/TransactionPage/TransactionDetails.tsx
@@ -191,8 +191,7 @@ const AccountBalance = ({ receipt, onResolve }: { receipt: TransactionReceiptPar
 	const getBalance = () => {
 		const { from, blockNumber } = receipt
 		waitFor(async () => {
-			const provider = providers.browserProvider
-			return await provider.getBalance(from, blockNumber)
+			return await providers.browserProvider.getBalance(from, blockNumber)
 		})
 	}
 

--- a/app/ts/library/ethereum.ts
+++ b/app/ts/library/ethereum.ts
@@ -1,6 +1,6 @@
 import { TransactionResponse, Interface, id, TransactionReceipt, Log, Eip1193Provider, formatEther } from 'ethers'
 import { ERC20ABI } from './ERC20ABI.js'
-import { WalletError } from './exceptions.js'
+import { ApplicationError } from '../store/errors.js'
 
 export interface WithEthereum {
 	ethereum: Eip1193Provider
@@ -23,7 +23,7 @@ export function assertsEthereumObservable(ethereum: unknown): asserts ethereum i
 }
 
 export function assertsWithEthereum(global: unknown): asserts global is WithEthereum {
-	if (!withEthereum(global)) throw new WalletError()
+	if (!withEthereum(global)) throw new ApplicationError('WALLET_MISSING')
 }
 
 export const calculateGasFee = (effectiveGasPrice: bigint, gasUsed: bigint) => {

--- a/app/ts/library/exceptions.ts
+++ b/app/ts/library/exceptions.ts
@@ -25,19 +25,3 @@ export class EthereumJsonRpcError extends Error {
 export function isEthereumJsonRpcError(error: unknown): error is EthereumJsonRpcErrorSignature {
 	return error instanceof Object && 'error' in error && error.error instanceof Object && 'code' in error.error && typeof error.error.code === 'number' && 'message' in error.error && typeof error.error.message === 'string'
 }
-
-export class ConnectAttemptError extends Error {
-	constructor(message: string = 'Connection attempt error.') {
-		super()
-		this.message = message
-		Object.setPrototypeOf(this, ConnectAttemptError.prototype)
-	}
-}
-
-export class WalletError extends Error {
-	constructor(message: string = 'Wallet not installed or incompatible.') {
-		super()
-		this.message = message
-		Object.setPrototypeOf(this, WalletError.prototype)
-	}
-}

--- a/app/ts/store/account.ts
+++ b/app/ts/store/account.ts
@@ -1,33 +1,36 @@
-import { assertsEthereumObservable } from '../library/ethereum.js'
+import { assertsEthereumObservable, assertsWithEthereum } from '../library/ethereum.js'
 import { AsyncProperty, useAsyncState } from '../library/preact-utilities.js'
+import { ApplicationError } from './errors.js'
+import { useNotice } from './notice.js'
 import { useProviders } from './provider.js'
 import { effect, signal, useSignalEffect } from '@preact/signals'
-import { ApplicationError } from '../store/errors.js'
 import { getAddress } from 'ethers'
 
 const address = signal<AsyncProperty<string>>({ state: 'inactive' })
 
 export function useAccount() {
-	const providers = useProviders()
+	const { notify } = useNotice()
+	const provider = useProviders()
 	const { value: query, waitFor } = useAsyncState<string>()
 
 	const connect = () => {
 		waitFor(async () => {
-			const provider = providers.browserProvider
-			const signer = await provider.getSigner()
-			return getAddress(signer.address)
+			try {
+				const signer = await provider.browserProvider.getSigner()
+				return getAddress(signer.address)
+			} catch (error) {
+				let errorMessage = 'An unknown error occurred.'
+				if (error instanceof ApplicationError) errorMessage = error.message
+				notify({ message: errorMessage, title: 'Unable to connect' })
+				throw error
+			}
 		})
 	}
 
 	const attemptToConnect = () => {
 		waitFor(async () => {
-			try {
-				const provider = providers.browserProvider
-				const [signer] = await provider.listAccounts()
-				return getAddress(signer.address)
-			} catch (e) {
-				throw new ApplicationError('UNKNOWN')
-			}
+			const [signer] = await provider.browserProvider.listAccounts()
+			return getAddress(signer.address)
 		})
 	}
 
@@ -54,6 +57,7 @@ const handleAccountChanged = ([newAddress]: string[]) => {
 
 const removeAccountChangedListener = effect(() => {
 	if (address.value.state !== 'resolved') return
+	assertsWithEthereum(window)
 	assertsEthereumObservable(window.ethereum)
 	window.ethereum.on('accountsChanged', handleAccountChanged)
 })

--- a/app/ts/store/account.ts
+++ b/app/ts/store/account.ts
@@ -2,7 +2,7 @@ import { assertsEthereumObservable } from '../library/ethereum.js'
 import { AsyncProperty, useAsyncState } from '../library/preact-utilities.js'
 import { useProviders } from './provider.js'
 import { effect, signal, useSignalEffect } from '@preact/signals'
-import { ConnectAttemptError } from '../library/exceptions.js'
+import { ApplicationError } from '../store/errors.js'
 import { getAddress } from 'ethers'
 
 const address = signal<AsyncProperty<string>>({ state: 'inactive' })
@@ -13,7 +13,7 @@ export function useAccount() {
 
 	const connect = () => {
 		waitFor(async () => {
-			const provider = providers.browserProvider.value
+			const provider = providers.browserProvider
 			const signer = await provider.getSigner()
 			return getAddress(signer.address)
 		})
@@ -21,10 +21,13 @@ export function useAccount() {
 
 	const attemptToConnect = () => {
 		waitFor(async () => {
-			if (providers.provider === undefined) throw new ConnectAttemptError()
-			const provider = providers.browserProvider.value
-			const [signer] = await provider.listAccounts()
-			return getAddress(signer.address)
+			try {
+				const provider = providers.browserProvider
+				const [signer] = await provider.listAccounts()
+				return getAddress(signer.address)
+			} catch (e) {
+				throw new ApplicationError('UNKNOWN')
+			}
 		})
 	}
 

--- a/app/ts/store/network.ts
+++ b/app/ts/store/network.ts
@@ -10,7 +10,7 @@ export function useNetwork() {
 	const { value: query, waitFor } = useAsyncState<Network>()
 
 	const getNetwork = () => {
-		waitFor(async () => await providers.browserProvider.value.getNetwork())
+		waitFor(async () => await providers.browserProvider.getNetwork())
 	}
 
 	const listenForQueryChanges = () => {
@@ -19,7 +19,7 @@ export function useNetwork() {
 	}
 
 	const listenForProviderChanges = () => {
-		if (providers.provider.value === undefined) return
+		if (providers.browserProvider === undefined) return
 		getNetwork()
 	}
 

--- a/app/ts/store/network.ts
+++ b/app/ts/store/network.ts
@@ -19,7 +19,6 @@ export function useNetwork() {
 	}
 
 	const listenForProviderChanges = () => {
-		if (providers.browserProvider === undefined) return
 		getNetwork()
 	}
 

--- a/app/ts/store/provider.ts
+++ b/app/ts/store/provider.ts
@@ -1,25 +1,14 @@
 import { effect, signal } from '@preact/signals'
 import { assertsEthereumObservable, assertsWithEthereum } from '../library/ethereum.js'
 import { BrowserProvider } from 'ethers'
-import { ApplicationError } from './errors.js'
 
 const provider = signal<BrowserProvider | undefined>(undefined)
 
 export function useProviders() {
 	return {
 		get browserProvider() {
-			if (provider.value !== undefined) return provider.value
-
-			try {
-				assertsWithEthereum(window)
-				provider.value = new BrowserProvider(window.ethereum)
-				return provider.value
-			} catch (exception) {
-				let errorMessage = 'An unknown error occurred.'
-				if (exception instanceof ApplicationError) errorMessage = exception.message
-				if (typeof exception === 'string') errorMessage = exception
-				throw new Error(errorMessage)
-			}
+			assertsWithEthereum(window)
+			return new BrowserProvider(window.ethereum)
 		},
 	}
 }
@@ -34,6 +23,7 @@ const handleChainChange = async () => {
 
 const removeChainChangeListener = effect(() => {
 	if (provider.value === undefined) return
+	assertsWithEthereum(window)
 	assertsEthereumObservable(window.ethereum)
 	window.ethereum.on('chainChanged', handleChainChange)
 })

--- a/app/ts/store/provider.ts
+++ b/app/ts/store/provider.ts
@@ -1,29 +1,27 @@
-import { effect, signal, useComputed } from '@preact/signals'
+import { effect, signal } from '@preact/signals'
 import { assertsEthereumObservable, assertsWithEthereum } from '../library/ethereum.js'
-import { WalletError } from '../library/exceptions.js'
 import { BrowserProvider } from 'ethers'
+import { ApplicationError } from './errors.js'
 
 const provider = signal<BrowserProvider | undefined>(undefined)
 
 export function useProviders() {
-	const getbrowserProvider = () => {
-		if (provider.value !== undefined) return provider.value
+	return {
+		get browserProvider() {
+			if (provider.value !== undefined) return provider.value
 
-		try {
-			assertsWithEthereum(window)
-			provider.value = new BrowserProvider(window.ethereum)
-			return provider.value
-		} catch (exception) {
-			let errorMessage = 'An unknown error occurred.'
-			if (exception instanceof WalletError) errorMessage = exception.message
-			if (typeof exception === 'string') errorMessage = exception
-			throw new Error(errorMessage)
-		}
+			try {
+				assertsWithEthereum(window)
+				provider.value = new BrowserProvider(window.ethereum)
+				return provider.value
+			} catch (exception) {
+				let errorMessage = 'An unknown error occurred.'
+				if (exception instanceof ApplicationError) errorMessage = exception.message
+				if (typeof exception === 'string') errorMessage = exception
+				throw new Error(errorMessage)
+			}
+		},
 	}
-
-	const browserProvider = useComputed(getbrowserProvider)
-
-	return { provider, browserProvider }
 }
 
 const handleChainChange = async () => {

--- a/app/ts/store/tokens.ts
+++ b/app/ts/store/tokens.ts
@@ -69,7 +69,7 @@ export function useTokenQuery() {
 			const chainId = network.value.value.chainId
 
 			try {
-				const provider = providers.browserProvider.value
+				const provider = providers.browserProvider
 				const contract = new Contract(tokenAddress.value, ERC20ABI, provider)
 				const name = await contract.name()
 				const symbol = await contract.symbol()
@@ -183,7 +183,7 @@ export function useTokenBalance() {
 
 	const getTokenBalance = (accountAddress: string, tokenAddress: string) => {
 		waitFor(async () => {
-			const provider = providers.browserProvider.value
+			const provider = providers.browserProvider
 			const contract = new Contract(tokenAddress, ERC20ABI, provider)
 			return await contract.balanceOf(accountAddress)
 		})

--- a/app/ts/store/tokens.ts
+++ b/app/ts/store/tokens.ts
@@ -69,8 +69,7 @@ export function useTokenQuery() {
 			const chainId = network.value.value.chainId
 
 			try {
-				const provider = providers.browserProvider
-				const contract = new Contract(tokenAddress.value, ERC20ABI, provider)
+				const contract = new Contract(tokenAddress.value, ERC20ABI, providers.browserProvider)
 				const name = await contract.name()
 				const symbol = await contract.symbol()
 				const decimals = await contract.decimals()
@@ -183,8 +182,7 @@ export function useTokenBalance() {
 
 	const getTokenBalance = (accountAddress: string, tokenAddress: string) => {
 		waitFor(async () => {
-			const provider = providers.browserProvider
-			const contract = new Contract(tokenAddress, ERC20ABI, provider)
+			const contract = new Contract(tokenAddress, ERC20ABI, providers.browserProvider)
 			return await contract.balanceOf(accountAddress)
 		})
 	}

--- a/app/ts/store/transaction.ts
+++ b/app/ts/store/transaction.ts
@@ -11,7 +11,7 @@ export function useTransaction(transactionHash: string) {
 
 	const getTransactionResponse = (transactionHash: string) => {
 		waitForResponse(async () => {
-			const provider = providers.browserProvider.value
+			const provider = providers.browserProvider
 			const result = await provider.getTransaction(transactionHash)
 			// TransactionResult can actually be null?
 			if (result === null) throw new Error('Transaction was not found on chain!')

--- a/app/ts/store/transfer.ts
+++ b/app/ts/store/transfer.ts
@@ -23,9 +23,7 @@ export function useTransfer() {
 
 	const send = () => {
 		waitFor(async () => {
-			const provider = providers.browserProvider
-			if (provider === undefined) throw new Error('Web3Provider is not instantiated.')
-			const signer = await provider.value.getSigner()
+			const signer = await providers.browserProvider.getSigner()
 			const to = getAddress(data.value.recipientAddress)
 
 			// Ether transfer

--- a/app/ts/types.ts
+++ b/app/ts/types.ts
@@ -1,11 +1,3 @@
-import { Eip1193Provider } from 'ethers'
-
-declare global {
-	interface Window {
-		ethereum?: Eip1193Provider
-	}
-}
-
 export type HexString = `0x${string}`
 
 // makes a single property optional


### PR DESCRIPTION
Redeclared the useProvider response to be a getter. Some errors were silently swallowed (maybe within effects) which is hard to drill down to