### PR TITLE
Add storage key check before update

### DIFF
--- a/app/ts/store/favorites.ts
+++ b/app/ts/store/favorites.ts
@@ -41,6 +41,7 @@ effect(() => {
 
 export function useFavorites() {
 	const syncCacheChange = (event: StorageEvent) => {
+		if (event.key !== FAVORITES_CACHE_ID) return
 		const newValue = event.newValue !== null ? (JSON.parse(event.newValue) as FavoriteModel[]) : []
 		favorites.value = newValue
 	}

--- a/app/ts/store/recent-transfers.ts
+++ b/app/ts/store/recent-transfers.ts
@@ -21,6 +21,7 @@ const recentTxns = signal(getSessionStorageCache())
 
 export const useRecentTransfers = () => {
 	const syncCacheChange = (event: StorageEvent) => {
+		if (event.key !== STORAGE_KEY_RECENTS) return
 		const newValue = event.newValue !== null ? (JSON.parse(event.newValue) as RecentTransaction[]) : []
 		recentTxns.value = newValue
 	}


### PR DESCRIPTION
update coming from browser storage is causing cache to be corrupt. added checks that syncing from storage to state are mapped by it's corresponding keys