### PR TITLE
Enhance error message UI

### DIFF
--- a/app/css/index.css
+++ b/app/css/index.css
@@ -526,6 +526,10 @@ input[type='password']:autofill {
 	inset: 0px;
 }
 
+.bottom-2 {
+	bottom: 0.5rem;
+}
+
 .bottom-4 {
 	bottom: 1rem;
 }
@@ -552,6 +556,10 @@ input[type='password']:autofill {
 
 .z-50 {
 	z-index: 50;
+}
+
+.col-span-2 {
+	grid-column: span 2 / span 2;
 }
 
 .col-span-full {
@@ -608,6 +616,10 @@ input[type='password']:autofill {
 
 .mb-8 {
 	margin-bottom: 2rem;
+}
+
+.mt-2 {
+	margin-top: 0.5rem;
 }
 
 .mt-8 {
@@ -978,6 +990,10 @@ input[type='password']:autofill {
 	white-space: nowrap;
 }
 
+.whitespace-pre-wrap {
+	white-space: pre-wrap;
+}
+
 .rounded {
 	border-radius: 0.25rem;
 }
@@ -1156,11 +1172,6 @@ input[type='password']:autofill {
 	padding-right: 1rem;
 }
 
-.py-1 {
-	padding-top: 0.25rem;
-	padding-bottom: 0.25rem;
-}
-
 .py-2 {
 	padding-top: 0.5rem;
 	padding-bottom: 0.5rem;
@@ -1278,8 +1289,20 @@ input[type='password']:autofill {
 	color: rgb(255 255 255 / 0.5);
 }
 
+.text-white\/75 {
+	color: rgb(255 255 255 / 0.75);
+}
+
 .text-white\/80 {
 	color: rgb(255 255 255 / 0.8);
+}
+
+.underline {
+	text-decoration-line: underline;
+}
+
+.underline-offset-2 {
+	text-underline-offset: 2px;
 }
 
 .opacity-0 {
@@ -1555,6 +1578,14 @@ input[type='password']:autofill {
 
 .disabled\:hover\:bg-transparent:hover:disabled {
 	background-color: transparent;
+}
+
+.disabled\:hover\:text-white\/30:hover:disabled {
+	color: rgb(255 255 255 / 0.3);
+}
+
+.group:hover .group-hover\:block {
+	display: block;
 }
 
 .peer:checked ~ .peer-checked\:hidden {

--- a/app/ts/components/CopyButton.tsx
+++ b/app/ts/components/CopyButton.tsx
@@ -1,14 +1,19 @@
 import { useSignal, useSignalEffect } from '@preact/signals'
-import { ComponentChild } from 'preact'
+import { ComponentChild, JSX } from 'preact'
+import { useNotification } from '../context/Notification.js'
 import * as Icon from './Icon/index.js'
 
 type CopyButtonProps = {
 	value: string
-	label: ComponentChild
+	withLabel?: boolean
+	// for deprecation: use `withLabel` to display text label
+	label?: ComponentChild
 }
 
-export const CopyButton = ({ value, label }: CopyButtonProps) => {
+export const CopyButton = ({ value, label, withLabel }: CopyButtonProps) => {
 	const isCopied = useSignal(false)
+	const { notify } = useNotification()
+	const hasLabel = label || withLabel
 
 	const handleClick = async () => {
 		await navigator.clipboard.writeText(value)
@@ -22,18 +27,22 @@ export const CopyButton = ({ value, label }: CopyButtonProps) => {
 		}, 1000)
 	})
 
+	useSignalEffect(() => {
+		if (!isCopied.value) return
+		notify({ message: 'Copied information may contain private data.', title: 'Copied text to clipboard' })
+	})
+
 	if (isCopied.value) {
-		return (
-			<button type='button' class='text-xs text-white/30 bg-white/10 px-2 py-1 uppercase whitespace-nowrap flex items-center gap-1' onClick={handleClick} disabled>
-				<span>Copied!</span>
-				<Icon.Check />
-			</button>
-		)
+		return <Button onClick={handleClick} disabled><Icon.Check /> {hasLabel ? <span>copied! </span> : <></>} </Button>
 	}
 
+	return <Button onClick={handleClick}><Icon.Copy />{hasLabel ? <span>copy </span> : <></>}</Button>
+}
+
+const Button = ({ children, ...props }: JSX.HTMLAttributes<HTMLButtonElement>) => {
 	return (
-		<button type='button' class='text-xs text-white/50 bg-white/10 px-2 py-1 uppercase whitespace-nowrap flex items-center focus:text-white hover:text-white' onClick={handleClick}>
-			{label}
+		<button type='button' title='Copy' class='text-xs text-white/50 bg-white/10 px-3 h-8 uppercase whitespace-nowrap flex gap-1 items-center focus:text-white hover:text-white hover:bg-white/20 disabled:text-white/30 disabled:hover:text-white/30' { ...props }>
+			{children}
 		</button>
 	)
 }

--- a/app/ts/components/TransferResult.tsx
+++ b/app/ts/components/TransferResult.tsx
@@ -1,4 +1,4 @@
-import { useComputed } from '@preact/signals'
+import { useComputed, useSignal } from '@preact/signals'
 import { useWallet } from '../context/Wallet.js'
 import { useNotification } from '../context/Notification.js'
 import { useTokenManager } from '../context/TokenManager.js'
@@ -6,6 +6,7 @@ import { useTransfer } from '../context/Transfer.js'
 import { humanReadableEthersError, isEthersError } from '../library/errors.js'
 import { areEqualStrings } from '../library/utilities.js'
 import { EthereumAddress } from '../schema.js'
+import { CopyButton } from './CopyButton.js'
 
 export const TransferResult = () => {
 	const { account } = useWallet()
@@ -46,21 +47,43 @@ export const TransferResult = () => {
 				errorMessage = message
 			}
 
-			return (
-				<div class='border border-red-400/50 bg-red-400/10 px-4 py-3 grid grid-cols-[min-content,1fr] grid-rows-[min-content,min-content] gap-x-3 items-center'>
-					<div class='row-span-2'>
-						<ExclamationIcon />
-					</div>
-					<div>
-						<div class='font-semibold leading-tight'>Transaction failed!</div>
-						<div class='text-sm text-white/50 leading-tight'>{errorMessage}</div>
-					</div>
-				</div>
-			)
+			return <ErrorDetails summary={errorMessage} message={txError.message} />
 		case 'resolved':
 		case 'pending':
 			return <></>
 	}
+}
+
+const ErrorDetails = ({ message, summary }: { message: string, summary: string }) => {
+	const displayMessage = useSignal(false)
+	const toggleMessageDisplay = () => displayMessage.value = !displayMessage.peek()
+
+	return (
+		<div class='border border-red-400/50 bg-red-400/10 px-4 py-3 grid grid-cols-[min-content,1fr] gap-x-3 items-center'>
+			<div>
+				<ExclamationIcon />
+			</div>
+			<div>
+				<div class='font-semibold'>Transaction failed!</div>
+				<p>
+					<span class='text-sm text-white/50'>{summary}.</span>&nbsp;
+					<button type='button' class='appearance-none outline-none underline text-sm text-white/75 underline-offset-2 focus|hover:text-white' onClick={toggleMessageDisplay}>{displayMessage.value ? 'Hide' : 'Show'} details</button>
+				</p>
+			</div>
+			<div class='col-span-2'>
+				{
+					displayMessage.value ? (
+						<div class='border border-white/10 bg-white/5 px-3 py-2 mt-2 group relative'>
+							<pre class='whitespace-pre-wrap text-sm text-white/30 mb-2'>{message}</pre>
+							<div class='absolute right-2 bottom-2 hidden group-hover:block'>
+								<CopyButton value={message} withLabel />
+							</div>
+						</div>
+					) : <></>
+				}
+			</div>
+		</div>
+	)
 }
 
 type ConfirmFieldProps = {


### PR DESCRIPTION
Allow user view more details of an error and copy raw error message which can be handy for debugging

| <img width="989" alt="Screenshot 2023-11-07 at 9 12 53 AM" src="https://github.com/DarkFlorist/lunaria/assets/1169838/b1704532-8414-4fe8-8e90-742b224d919a"> |
|:--:|
| *default view* |

| <img width="989" alt="Screenshot 2023-11-07 at 9 12 33 AM" src="https://github.com/DarkFlorist/lunaria/assets/1169838/7344d686-3be9-45ee-a2d1-94ba873c0292"> |
|:--:|
| *expanded view* |
