### PR TITLE
Consider non-checksummed address as invalid address

### DIFF
--- a/app/ts/schema.ts
+++ b/app/ts/schema.ts
@@ -50,9 +50,8 @@ export function createUnitParser(decimals?: bigint): funtypes.ParsedValue<funtyp
 
 export const AddressParser: funtypes.ParsedValue<funtypes.String, string>['config'] = {
 	parse: value => {
-		const addressString = value.toLowerCase()
-		if (!isAddress(addressString)) return { success: false, message: `${value} is not a valid address string.` }
-		else return { success: true, value: getAddress(addressString) }
+		if (!isAddress(value)) return { success: false, message: `${value} is not a valid address string.` }
+		else return { success: true, value: getAddress(value) }
 	},
 	serialize: funtypes.String.safeParse,
 }


### PR DESCRIPTION
Ethers already does checksum so utilizing it to determine bad addresses

|variation|address|validation|
|--|--|--:|
| lowercase | `0x4b35d49dc14ee21b86bb0290b68f071b18a5fe96` | ✅ |
| uppercase | `0x4B35D49DC14EE21B86BB0290B68F071B18A5FE96` | ✅ |
| mixed-case (checksummed) | `0x4b35D49dC14EE21B86bb0290b68F071b18a5FE96` | ✅ |
| mixed-case (invalid checksum) | `0x4b35D49dC14EE21B86bb0290b68F071b18a5Fe96` | ❌ |

Fixes #222 