### PR TITLE
Only check token balance when necessary

### DIFF
--- a/app/ts/components/TokenPicker.tsx
+++ b/app/ts/components/TokenPicker.tsx
@@ -148,6 +148,7 @@ const AssetCard = ({ token }: { token?: ERC20Token }) => {
 }
 
 const AssetBalance = ({ token }: { token?: ERC20Token }) => {
+	const { stage } = useTokenManager()
 	const { browserProvider, blockNumber } = useEthereumProvider()
 	const { account } = useWallet()
 	const { value: query, waitFor } = useAsyncState<bigint>()
@@ -167,7 +168,7 @@ const AssetBalance = ({ token }: { token?: ERC20Token }) => {
 	}
 
 	useSignalEffect(() => {
-		if (!blockNumber.value || account.value.state !== 'resolved') return
+		if (!stage.value || !blockNumber.value || account.value.state !== 'resolved') return
 		getAssetBalance(account.value.value)
 	})
 


### PR DESCRIPTION
Balance will now be only auto-updating when the token picker is open

Resolves #227 