### PR TITLE
Make yaml use spaces instead of tabs.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 quote_type = single
 
-[*.yml]
+[*.{yml,yaml}]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,4 @@ quote_type = single
 
 [*.{yml,yaml}]
 indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,9 +2,11 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 2
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 quote_type = single
+
+[*.yml]
+indent_style = space


### PR DESCRIPTION
YAML is silly and requires spaces to work properly, so `.editorconfig` should say so.