### PR TITLE
Fix template not loading on page load

### DIFF
--- a/app/ts/components/SetupTransfer.tsx
+++ b/app/ts/components/SetupTransfer.tsx
@@ -77,7 +77,7 @@ const TransferForm = ({ children }: { children: ComponentChildren }) => {
 	}
 
 	const listenForWalletsChainChange = () => {
-		if (network.value.state !== 'resolved') return
+		if (network.value.state === 'resolved') return
 		// reset token input as it may not exist on the active network
 		input.value = { ...input.peek(), token: undefined }
 	}

--- a/app/ts/components/TransferPage/index.tsx
+++ b/app/ts/components/TransferPage/index.tsx
@@ -73,6 +73,9 @@ const MainPanel = () => {
 const LeftPanel = () => {
 	const { nav, main } = usePanels()
 
+	// full url without the hash route
+	const [baseUrl] = window.location.href.split('#')
+
 	return (
 		<Navigation>
 			<Header>
@@ -91,7 +94,7 @@ const LeftPanel = () => {
 
 			<div class='pl-4 mb-4'>
 				<div class='text-white/30 text-sm'>Actions</div>
-				<a href={window.location.href}>
+				<a href={baseUrl}>
 					<div class='grid grid-cols-[auto,1fr] items-center gap-4 mb-4'>
 						<div class='bg-white/30 w-10 h-10 rounded-full' />
 						<div class='py-2 leading-tight'>


### PR DESCRIPTION
The selected template isn't applied when the page loads; clicking template correctly applies it tho

#### Bug
The token selection is correctly set with value coming from template, however, it is being set to ETH quickly afterwards

#### Findings & Fix

The selected token should be reset to ETH when the app detects a change in network (a contract address may only exist on the previous network). The reset function however is being triggered when the network's chain id is resolved (which happens when the page loads) instead of when it is being fetched again (when a chainChanged event happens)

_**The PR also included fix in anchor link for creating new/blank transfer_

---
Resolves #259 