### PR TITLE
Fix premature script exit

### DIFF
--- a/.github/workflows/ipfs-deploy.yml
+++ b/.github/workflows/ipfs-deploy.yml
@@ -119,7 +119,7 @@ jobs:
             --header "Authorization: Bearer $GITHUB_TOKEN" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             --data "$REQUEST_DATA" \
-            --write-out "%{http_code}" \ # append the status code to response
+            --write-out "%{http_code}" \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/releases"
           )
 


### PR DESCRIPTION
The hash line here is supposed to be a yaml comment but dealing with multi-line scripts, this syntax is invalid and will break the script.

https://github.com/DarkFlorist/lunaria/blob/94c546abb61cc7f090421705d4ee35e158290e61/.github/workflows/ipfs-deploy.yml#L122