### PR TITLE
Remove keydonix.com from ipfs mirror

### DIFF
--- a/.github/workflows/ipfs-deploy.yml
+++ b/.github/workflows/ipfs-deploy.yml
@@ -90,7 +90,6 @@ jobs:
           _requires Brave Browser or IPFS Desktop_
           [https://$IPFS_HASH.ipfs.nftstorage.link](https://$IPFS_HASH.ipfs.nftstorage.link)
           [https://$IPFS_HASH.ipfs.zoltu.io](https://$IPFS_HASH.ipfs.zoltu.io)
-          [https://$IPFS_HASH.ipfs.keydonix.com](https://$IPFS_HASH.ipfs.keydonix.com)
           [https://$IPFS_HASH.ipfs.cf-ipfs.com](https://$IPFS_HASH.ipfs.cf-ipfs.com)
           [https://$IPFS_HASH.ipfs.w3s.link](https://$IPFS_HASH.ipfs.w3s.link)
           EOF


### PR DESCRIPTION
Removing `ipfs.keydonix.com` from release script for now