### PR TITLE
Bump curl to 7.88.1-10+deb12u7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,8 @@ FROM ipfs/kubo:v0.25.0@sha256:0c17b91cab8ada485f253e204236b712d0965f3d463cb5b606
 # Create the base image
 FROM debian:12.6-slim@sha256:39868a6f452462b70cf720a8daff250c63e7342970e749059c105bf7c1e8eeaf
 
-# Add curl to the base image (7.88.1-10+deb12u5)
-# Add jq to the base image (1.6-2.1)
-RUN apt-get update && apt-get install -y curl=7.88.1-10+deb12u6 jq=1.6-2.1
+# Add `curl` & `jq` to the base image
+RUN apt-get update && apt-get install -y curl=7.88.1-10+deb12u7 jq=1.6-2.1
 
 # Install kubo and initialize ipfs
 COPY --from=ipfs-kubo /usr/local/bin/ipfs /usr/local/bin/ipfs


### PR DESCRIPTION
Failed to build with curl version mismatch in apt package 

Update Version: `7.88.1-10+deb12u7`